### PR TITLE
Expose web3 library v.0.20.6 to upper level

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
         "debug": "^3.1.0",
         "ethereumjs-util": "^5.2.0",
         "ethereumjs-wallet": "^0.6.2",
-        "web3-provider-engine": "^14.0.5"
+        "web3-provider-engine": "^14.0.5",
+        "web3": "^0.20.6",
     },
     "devDependencies": {
-        "web3": "^0.20.6",
         "ganache-core": "^2.1.0",
         "mocha": "^5.1.1"
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "ethereumjs-util": "^5.2.0",
         "ethereumjs-wallet": "^0.6.2",
         "web3-provider-engine": "^14.0.5",
-        "web3": "^0.20.6",
+        "web3": "^0.20.6"
     },
     "devDependencies": {
         "ganache-core": "^2.1.0",

--- a/web3.js
+++ b/web3.js
@@ -1,0 +1,1 @@
+module.exports = require('web3');


### PR DESCRIPTION
In situations when a project (truffle project) uses itself `web3 v.1.0.0` and we want to use `web3-hdwallet-provider` which uses `web3 v.0.20.6` then we can reference an old web3 along with our web3-hdwallet-provider like this: `const Web3 = require('web3-hdwallet-provider/web3');`
